### PR TITLE
[DM-25484] Extend kafka-aggregator example to process an arbitrary number of source topics for performance evaluation 

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -64,18 +64,14 @@ flake8==3.8.3 \
     --hash=sha256:15e351d19611c887e482fb960eae4d44845013cc142d42896e9862f775d8cf5c \
     --hash=sha256:f04b9fcbac03b0a3e58c0ab3a0ecc462e023a9faf046d57794184028123aa208 \
     # via -r requirements/dev.in, flake8-docstrings
-identify==1.4.19 \
-    --hash=sha256:249ebc7e2066d6393d27c1b1be3b70433f824a120b1d8274d362f1eb419e3b52 \
-    --hash=sha256:781fd3401f5d2b17b22a8b18b493a48d5d948e3330634e82742e23f9c20234ef \
+identify==1.4.20 \
+    --hash=sha256:acf0712ab4042642e8f44e9532d95c26fbe60c0ab8b6e5b654dd1bc6512810e0 \
+    --hash=sha256:b2cd24dece806707e0b50517c1b3bcf3044e0b1cb13a72e7d34aa31c91f2a55a \
     # via pre-commit
 idna==2.9 \
     --hash=sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb \
     --hash=sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa \
     # via yarl
-importlib-metadata==1.6.1 \
-    --hash=sha256:0505dd08068cfec00f53a74a0ad927676d7757da81b7436a6eefe4c7cf75c545 \
-    --hash=sha256:15ec6c0fd909e893e3a08b3a7c76ecb149122fb14b7efe1199ddd4c7c57ea958 \
-    # via flake8, pluggy, pre-commit, pytest, virtualenv
 mccabe==0.6.1 \
     --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
     --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f \
@@ -107,21 +103,21 @@ mypy-extensions==0.4.3 \
     --hash=sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d \
     --hash=sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8 \
     # via mypy
-mypy==0.780 \
-    --hash=sha256:00cb1964a7476e871d6108341ac9c1a857d6bd20bf5877f4773ac5e9d92cd3cd \
-    --hash=sha256:127de5a9b817a03a98c5ae8a0c46a20dc44442af6dcfa2ae7f96cb519b312efa \
-    --hash=sha256:1f3976a945ad7f0a0727aafdc5651c2d3278e3c88dee94e2bf75cd3386b7b2f4 \
-    --hash=sha256:2f8c098f12b402c19b735aec724cc9105cc1a9eea405d08814eb4b14a6fb1a41 \
-    --hash=sha256:4ef13b619a289aa025f2273e05e755f8049bb4eaba6d703a425de37d495d178d \
-    --hash=sha256:5d142f219bf8c7894dfa79ebfb7d352c4c63a325e75f10dfb4c3db9417dcd135 \
-    --hash=sha256:62eb5dd4ea86bda8ce386f26684f7f26e4bfe6283c9f2b6ca6d17faf704dcfad \
-    --hash=sha256:64c36eb0936d0bfb7d8da49f92c18e312ad2e3ed46e5548ae4ca997b0d33bd59 \
-    --hash=sha256:75eed74d2faf2759f79c5f56f17388defd2fc994222312ec54ee921e37b31ad4 \
-    --hash=sha256:974bebe3699b9b46278a7f076635d219183da26e1a675c1f8243a69221758273 \
-    --hash=sha256:a5e5bb12b7982b179af513dddb06fca12285f0316d74f3964078acbfcf4c68f2 \
-    --hash=sha256:d31291df31bafb997952dc0a17ebb2737f802c754aed31dd155a8bfe75112c57 \
-    --hash=sha256:d3b4941de44341227ece1caaf5b08b23e42ad4eeb8b603219afb11e9d4cfb437 \
-    --hash=sha256:eadb865126da4e3c4c95bdb47fe1bb087a3e3ea14d39a3b13224b8a4d9f9a102 \
+mypy==0.781 \
+    --hash=sha256:1fe322a51df7ec60e4060c358422732359dda4467c1bd240f2172433b26b39be \
+    --hash=sha256:2bc1fe8f793f1b1809afd6f57c2d9b948e1bf525a78e4c2957392a383c86a4a4 \
+    --hash=sha256:43335f3ff3288eb877de6d186ec08e10ea61093405189678756e14c7ccee4a9b \
+    --hash=sha256:5c75603ea44bffad0356df333bd1b411facad321e0692d6b0687d65d94fcd8e1 \
+    --hash=sha256:738a8df84da4e9ce1f59cbdebc7d1d03310149405df9a95308d4f2a62a6d7c13 \
+    --hash=sha256:845abd8a9537da01e6b96f091e2d6d4ece18e52339f81f9fbbac1b6db2aa8d2d \
+    --hash=sha256:94bb664868b5cf4ca1147d875a4c77883d8c605cf2e916853006e4c6194f1e84 \
+    --hash=sha256:b0c6ae0cb991a7a11013d0cc7edf8343184465b6e2dcbb9e44265c7bb3fde3af \
+    --hash=sha256:ca56382e6ebdeb3cb928ae4ce87031cc752a1eca40ff86abc14dc712def41798 \
+    --hash=sha256:d6e9611ae026be70604672cd71bee468cb231078d8d9b3d6b43f8dcbd4d9b776 \
+    --hash=sha256:d7c9255ba6626e1745bd68e1b85e3d7888844eaf38252fefb8157194e55fd3e9 \
+    --hash=sha256:e2f193a2076e4508a88c93c25348a1cea5e6b717ee50b4422a001e9ac819c3d5 \
+    --hash=sha256:e60674723cad7b7c7fc4e9075f7a9d5d927d23d290e30cf86aeb987ef135ca1d \
+    --hash=sha256:ec45f2a5935b291d86974a24e09676e467ac108d0c7ce94de44d7650c43a5805 \
     # via -r requirements/dev.in
 nodeenv==1.4.0 \
     --hash=sha256:4b0b77afa3ba9b54f4b6396e60b0c83f59eaeb2d63dc3cc7a70f7f4af96c82bc \
@@ -226,9 +222,9 @@ vcrpy==4.0.2 \
     --hash=sha256:9740c5b1b63626ec55cefb415259a2c77ce00751e97b0f7f214037baaf13c7bf \
     --hash=sha256:c4ddf1b92c8a431901c56a1738a2c797d965165a96348a26f4b2bbc5fa6d36d9 \
     # via pytest-vcr
-virtualenv==20.0.23 \
-    --hash=sha256:5102fbf1ec57e80671ef40ed98a84e980a71194cedf30c87c2b25c3a9e0b0107 \
-    --hash=sha256:ccfb8e1e05a1174f7bd4c163700277ba730496094fe1a58bea9d4ac140a207c8 \
+virtualenv==20.0.24 \
+    --hash=sha256:1b253c5d0e76afe24c76ce288cdd5dd01ac7deaa55f644998c74e5a799349522 \
+    --hash=sha256:680011aa2995fb8b7c2bbea7da7afd8dcaf382def7a3e02a1b1fba4b402aa8cf \
     # via pre-commit
 wcwidth==0.2.4 \
     --hash=sha256:79375666b9954d4a1a10739315816324c3e73110af9d0e102d906fdb0aec009f \
@@ -256,7 +252,3 @@ yarl==1.4.2 \
     --hash=sha256:d8cdee92bc930d8b09d8bd2043cedd544d9c8bd7436a77678dd602467a993080 \
     --hash=sha256:e15199cdb423316e15f108f51249e44eb156ae5dba232cb73be555324a1d49c2 \
     # via vcrpy
-zipp==3.1.0 \
-    --hash=sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b \
-    --hash=sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96 \
-    # via importlib-metadata

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -117,9 +117,9 @@ colorlog==4.1.0 \
     --hash=sha256:30aaef5ab2a1873dec5da38fd6ba568fa761c9fa10b40241027fa3edea47f3d2 \
     --hash=sha256:732c191ebbe9a353ec160d043d02c64ddef9028de8caae4cfa8bd49b6afed53e \
     # via mode
-croniter==0.3.33 \
-    --hash=sha256:03ad19baa220ca8bd105413c9f3bab2e7a1514046c20aeb7bf16805c07538eee \
-    --hash=sha256:8e383724066891901ee72dc543a8d520ac14a1f8a820920f2b21f74cd75c8b59 \
+croniter==0.3.34 \
+    --hash=sha256:15597ef0639f8fbab09cbf8c277fa8c65c8b9dbe818c4b2212f95dbc09c6f287 \
+    --hash=sha256:7186b9b464f45cf3d3c83a18bc2344cc101d7b9fd35a05f2878437b14967e964 \
     # via faust
 cython==0.29.20 \
     --hash=sha256:0754ec9d45518d0dbb5da72db2c8b063d40c4c51779618c68431054de179387f \

--- a/src/kafkaaggregator/aggregator.py
+++ b/src/kafkaaggregator/aggregator.py
@@ -114,6 +114,8 @@ class Aggregator:
         """
         logger.info(f"Make Faust record for topic {self._source_topic.name}.")
 
+        cls_name = self._source_topic.name.title().replace("-", "")
+
         fields = await self._source_topic.get_fields()
 
         self._aggregation_fields = self._create_aggregation_fields(
@@ -121,7 +123,7 @@ class Aggregator:
         )
 
         self._record = self._make_record(
-            cls_name="AggregationRecord",
+            cls_name=cls_name,
             fields=self._aggregation_fields,
             doc=f"Faust record for topic {self._source_topic.name}.",
         )

--- a/src/kafkaaggregator/cli.py
+++ b/src/kafkaaggregator/cli.py
@@ -2,17 +2,13 @@
 
 __all__ = ["main", "produce", "init_example"]
 
-import asyncio
-import json
 import logging
-import random
-from time import time
 
 from faust.cli import AppCommand, option
 
-from kafkaaggregator.app import app, config
+from kafkaaggregator.app import app
+from kafkaaggregator.example import AggregationExample
 from kafkaaggregator.generator import AgentGenerator
-from kafkaaggregator.topics import SourceTopic
 
 logger = logging.getLogger("kafkaaggregator")
 
@@ -41,53 +37,18 @@ def main() -> None:
 async def produce(
     self: AppCommand, frequency: float, max_messages: int
 ) -> None:
-    """Produce messages for the kafkaaggregator source topic."""
-    # Assume the source topic exists
-    src_topic = app.topic(config.source_topic_name)
-
-    logger.info(
-        f"Producing {max_messages} message(s) for {config.source_topic_name} "
-        f"at {frequency} Hz."
+    """Produce messages for the aggregation example."""
+    example = AggregationExample()
+    await example.produce(
+        app=app, frequency=frequency, max_messages=max_messages
     )
-
-    for i in range(max_messages):
-        value = random.random()
-        await src_topic.send(value=dict(time=time(), value=value))
-        await asyncio.sleep(1 / frequency)
 
 
 @app.command()
 async def init_example(self: AppCommand) -> None:
-    """Initialize the source topic used in the aggregation example.
-
-    The source topic has a fixed schema with a timestamp and a value. It is
-    used produce messages for the aggregation example. This topic is not
-    managed by Faust, it represents an external topic and thus needs to be
-    created in Kafka and its schema needs to registered in the Schema Registry.
-    """
-    source_topic = SourceTopic(name=config.source_topic_name)
-
-    schema = json.dumps(
-        dict(
-            type="record",
-            name="SourceTopic",
-            doc="Source topic with raw values.",
-            fields=[
-                dict(name="time", type="double"),
-                dict(name="value", type="double"),
-            ],
-        )
-    )
-
-    # Register source topic schema
-    await source_topic.register(schema=schema)
-
-    # Declare the source topic as an external topic in Faust. External topics
-    # do not have a corresponding model in Faust, thus value_type=bytes.
-    external_topic = app.topic(
-        source_topic.name, value_type=bytes, internal=False
-    )
-    await external_topic.declare()
+    """Initialize the source topic used in the aggregation example."""
+    example = AggregationExample()
+    await example.initialize(app=app)
 
 
 @app.command()

--- a/src/kafkaaggregator/config.py
+++ b/src/kafkaaggregator/config.py
@@ -73,13 +73,19 @@ class Configuration:
     workload of the application.
     """
 
-    source_topic_name: str = os.getenv(
-        "SOURCE_TOPIC", "kafkaaggregator-example"
+    source_topic_name_prefix: str = os.getenv(
+        "SOURCE_TOPIC_NAME_PREFIX", "example"
     )
-    """Name of the source topic used in the kafkaaggregator example."""
+    """Prefix for the source topic name used in the aggregation example."""
 
-    topic_regex: str = os.getenv("TOPIC_REGEX", "^kafkaaggregator-example$")
-    """Regex to select topics to aggregate."""
+    ntopics: int = int(os.getenv("NTOPICS", "10"))
+    """Number of source topics used in the aggregation example."""
+
+    nfields: int = int(os.getenv("NFIELDS", "10"))
+    """Number of fields for source topics used in the aggregation example."""
+
+    topic_regex: str = os.getenv("TOPIC_REGEX", "^example-[0-9][0-9][0-9]?$")
+    """Regex to select source topics to aggregate."""
 
     excluded_topics: List[str] = field(default_factory=list)
     """Topics excluded from aggregation."""

--- a/src/kafkaaggregator/example.py
+++ b/src/kafkaaggregator/example.py
@@ -1,0 +1,134 @@
+"""Aggregation example."""
+
+
+__all__ = ["AggregationExample"]
+
+import asyncio
+import json
+import logging
+import random
+from time import time
+
+import faust_avro
+
+from kafkaaggregator.app import config
+from kafkaaggregator.topics import SourceTopic
+
+AvroSchemaT = str
+
+logger = logging.getLogger("kafkaaggregator")
+
+
+class AggregationExampleError(RuntimeError):
+    """Raised when the number of source topics is unnexpected.
+
+    The number of source topics in Kafka must match the number of topics
+    initialized by the example.
+    """
+
+
+class AggregationExample:
+    """Initialize topics and produce messages for the aggregation example.
+
+    The aggregation example can be used to evaluate the performance of the
+    kafka-aggregator application.
+    """
+
+    MAX_NTOPICS = 999
+    MAX_NFIELDS = 999
+
+    def __init__(self) -> None:
+        self._ntopics = min(config.ntopics, AggregationExample.MAX_NTOPICS)
+        self._nfields = min(config.nfields, AggregationExample.MAX_NFIELDS)
+
+    def create_schema(self, name: str) -> AvroSchemaT:
+        """Create Avro schema for the source topic.
+
+        Parameters
+        ----------
+        source_topic_name : `str`
+            Name of the source topic.
+        """
+        fields = []
+        # A source topic needs a timestamp field
+        fields.append(dict(name="time", type="double"))
+
+        for n in range(self._nfields):
+            fields.append(dict(name=f"value{n}", type="double"))
+
+        schema = json.dumps(
+            dict(
+                type="record",
+                name=name.replace("-", "_"),
+                doc="Source topic with raw values.",
+                fields=fields,
+            )
+        )
+        return schema
+
+    async def initialize(self, app: faust_avro.App) -> None:
+        """Initialize source topics for the aggregation example.
+
+        The source topic is not managed by Faust, it is an external
+        topic. To initialize the topic, its schema needs to registered in
+        the Schema Registry and the topic itself needs to be created in Kafka.
+
+        Parameters
+        ----------
+        app : `faust_avro.App`
+            Faust application
+        """
+        for n in range(self._ntopics):
+            source_topic_name = f"{config.source_topic_name_prefix}-{n:03d}"
+            source_topic = SourceTopic(name=source_topic_name)
+            schema = self.create_schema(name=source_topic_name)
+            await source_topic.register(schema=schema)
+            # Declare the source topic as an external topic in Faust.
+            # External topics do not have a corresponding model, thus
+            # value_type=bytes.
+            external_topic = app.topic(
+                source_topic_name, value_type=bytes, internal=False
+            )
+            await external_topic.declare()
+
+    async def produce(
+        self, app: faust_avro.App, frequency: float, max_messages: int
+    ) -> None:
+        """Produce messages for the source topics in the aggregation example.
+
+        In the aggregation example we can specify the frequency in which the
+        messages are produced, the maximum number of messages for each source
+        topic and the number of fields in every message.
+
+        Parameters
+        ----------
+        app : `faust_avro.App`
+            Faust application
+        frequency : `float`
+            The frequency in Hz in wich messages are produced.
+        max_messages : `int`
+            The maximum number of messages to produce.
+        """
+        source_topic_names = SourceTopic.names()
+        if len(source_topic_names) != self._ntopics:
+            msg = (
+                "Unexpected number of source topics from Kafka. Hint: "
+                "verify if the topic_regex configuration matches the "
+                "source topic names."
+            )
+            raise AggregationExampleError(msg)
+        logger.info(
+            f"Producing {max_messages} message(s) at {frequency} Hz for each "
+            f"source topic."
+        )
+        for i in range(max_messages):
+            message = {"time": time()}
+            for n in range(self._nfields):
+                value = random.random()
+                message.update({f"value{n}": value})
+            # The same message is sent for all source topics
+            for source_topic_name in source_topic_names:
+                source_topic = app.topic(source_topic_name)
+                await source_topic.send(value=message)
+
+            await asyncio.sleep(1 / frequency)

--- a/src/kafkaaggregator/generator.py
+++ b/src/kafkaaggregator/generator.py
@@ -71,6 +71,8 @@ class AgentGenerator:
         context : `dict`
             A dictionary with values passed to the template.
         """
+        cls_name = source_topic_name.title().replace("-", "")
+
         topic_rename_format = config.topic_rename_format
 
         aggregation_topic_name = topic_rename_format.format(
@@ -78,6 +80,7 @@ class AgentGenerator:
         )
 
         context = dict(
+            cls_name=cls_name,
             source_topic_name=source_topic_name,
             aggregation_topic_name=aggregation_topic_name,
         )

--- a/src/kafkaaggregator/generator.py
+++ b/src/kafkaaggregator/generator.py
@@ -4,15 +4,13 @@ __all__ = ["AgentGenerator"]
 
 import logging
 import os
-import re
-from typing import Any, Mapping, Set
+from typing import Any, Mapping
 
 import aiofiles
 from jinja2 import Environment, PackageLoader, Template, TemplateError
-from kafka import KafkaConsumer
-from kafka.errors import KafkaError
 
 from kafkaaggregator.app import config
+from kafkaaggregator.topics import SourceTopic
 
 logger = logging.getLogger("kafkaaggregator")
 
@@ -31,52 +29,13 @@ class AgentGenerator:
     logger = logger
 
     def __init__(self) -> None:
-        self._source_topic_names = self._get_source_topic_names()
+        self._source_topic_names = SourceTopic.names()
         self._template: Template = self._load_template()
 
     @property
     def template(self) -> Template:
         """Get the agent template."""
         return self._template
-
-    @staticmethod
-    def _get_source_topic_names() -> Set[str]:
-        """Get a set of source topics to aggregate from Kafka.
-
-        Retrieve source topics based on the topic_regex and the excluded_topics
-        configuration parameters.
-
-        Returns
-        -------
-        source_topic_names : `set`
-            Set of source topics to aggregate.
-        """
-        logger.info("Discovering source topics...")
-        bootstrap_servers = [config.broker.replace("kafka://", "")]
-        try:
-            consumer = KafkaConsumer(
-                bootstrap_servers=bootstrap_servers, enable_auto_commit=False
-            )
-            source_topic_names: Set[str] = consumer.topics()
-        except KafkaError as e:
-            logger.error("Error retrieving topics from Kafka.")
-            raise e
-
-        if config.topic_regex:
-            pattern = re.compile(config.topic_regex)
-            source_topic_names = {
-                name for name in source_topic_names if pattern.match(name)
-            }
-
-        if config.excluded_topics:
-            excluded_topics = set(config.excluded_topics)
-            source_topic_names = source_topic_names - excluded_topics
-
-        n = len(source_topic_names)
-        s = ", ".join(source_topic_names)
-        logger.info(f"Found {n} topic(s): {s}")
-
-        return source_topic_names
 
     @staticmethod
     def _create_filepath(source_topic_name: str) -> str:

--- a/src/kafkaaggregator/templates/agent.j2
+++ b/src/kafkaaggregator/templates/agent.j2
@@ -37,13 +37,13 @@ aggregator = Aggregator(
 )
 
 # The Faust Record for the aggregation topic is created at runtime
-AggregationRecord = aggregator.async_create_record()
+{{ cls_name }} = aggregator.async_create_record()
 
 source_topic = app.topic("{{ source_topic_name }}")
 
 aggregation_topic = app.topic(
     "{{ aggregation_topic_name }}",
-    value_type=AggregationRecord,
+    value_type={{ cls_name }},
     internal=True
 )
 


### PR DESCRIPTION
This PR extends the `kafka-aggregator` example feature to be able to aggregate an arbitrary number of source topics and an arbitrary number of fields in each source topic so that we can use it to evaluate the `kafka-aggregator` performance. It adds the AggregationExample class and the configuration but does not change the CLI.