### PR TITLE
[DM-25645] Given the aggregation window size and frequency make sure the aggregator has enough data points to compute statistics

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -72,6 +72,10 @@ idna==2.9 \
     --hash=sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb \
     --hash=sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa \
     # via yarl
+importlib-metadata==1.6.1 \
+    --hash=sha256:0505dd08068cfec00f53a74a0ad927676d7757da81b7436a6eefe4c7cf75c545 \
+    --hash=sha256:15ec6c0fd909e893e3a08b3a7c76ecb149122fb14b7efe1199ddd4c7c57ea958 \
+    # via flake8, pluggy, pre-commit, pytest, virtualenv
 mccabe==0.6.1 \
     --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
     --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f \
@@ -154,8 +158,9 @@ pyparsing==2.4.7 \
     --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
     --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b \
     # via packaging
-pytest-asyncio==0.12.0 \
-    --hash=sha256:475bd2f3dc0bc11d2463656b3cbaafdbec5a47b47508ea0b329ee693040eebd2 \
+pytest-asyncio==0.14.0 \
+    --hash=sha256:2eae1e34f6c68fc0a9dc12d4bea190483843ff4708d24277c41568d6b6044f1d \
+    --hash=sha256:9882c0c6b24429449f5f969a5158b528f39bde47dc32e85b9f0403965017e700 \
     # via -r requirements/dev.in
 pytest-vcr==1.0.2 \
     --hash=sha256:23ee51b75abbcc43d926272773aae4f39f93aceb75ed56852d0bf618f92e1896 \
@@ -222,13 +227,13 @@ vcrpy==4.0.2 \
     --hash=sha256:9740c5b1b63626ec55cefb415259a2c77ce00751e97b0f7f214037baaf13c7bf \
     --hash=sha256:c4ddf1b92c8a431901c56a1738a2c797d965165a96348a26f4b2bbc5fa6d36d9 \
     # via pytest-vcr
-virtualenv==20.0.24 \
-    --hash=sha256:1b253c5d0e76afe24c76ce288cdd5dd01ac7deaa55f644998c74e5a799349522 \
-    --hash=sha256:680011aa2995fb8b7c2bbea7da7afd8dcaf382def7a3e02a1b1fba4b402aa8cf \
+virtualenv==20.0.25 \
+    --hash=sha256:f332ba0b2dfbac9f6b1da9f11224f0036b05cdb4df23b228527c2a2d5504aeed \
+    --hash=sha256:ffffcb3c78a671bb3d590ac3bc67c081ea2188befeeb058870cba13e7f82911b \
     # via pre-commit
-wcwidth==0.2.4 \
-    --hash=sha256:79375666b9954d4a1a10739315816324c3e73110af9d0e102d906fdb0aec009f \
-    --hash=sha256:8c6b5b6ee1360b842645f336d9e5d68c55817c26d3050f46b235ef2bc650e48f \
+wcwidth==0.2.5 \
+    --hash=sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784 \
+    --hash=sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83 \
     # via pytest
 wrapt==1.12.1 \
     --hash=sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7 \
@@ -252,3 +257,7 @@ yarl==1.4.2 \
     --hash=sha256:d8cdee92bc930d8b09d8bd2043cedd544d9c8bd7436a77678dd602467a993080 \
     --hash=sha256:e15199cdb423316e15f108f51249e44eb156ae5dba232cb73be555324a1d49c2 \
     # via vcrpy
+zipp==3.1.0 \
+    --hash=sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b \
+    --hash=sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96 \
+    # via importlib-metadata

--- a/src/kafkaaggregator/aggregator.py
+++ b/src/kafkaaggregator/aggregator.py
@@ -61,7 +61,7 @@ class Aggregator:
     def _create_aggregation_fields(
         fields: List[Field], excluded_field_names: List
     ) -> List[Field]:
-        """Create the aggregation topic fields based on the source topic fields.
+        """Create aggregation topic fields based on the source topic fields.
 
         Add the fields `time`, `window_size`, and `count` and fields for the
         `min`, `mean`, `stdev`, `median`, and `max` statistics for every

--- a/src/kafkaaggregator/aggregator.py
+++ b/src/kafkaaggregator/aggregator.py
@@ -163,7 +163,11 @@ class Aggregator:
         await self._aggregation_topic.register(schema=json.dumps(schema))
 
     def compute(
-        self, time: float, window_size: float, messages: List[Any]
+        self,
+        time: float,
+        window_size: float,
+        min_sample_size: int,
+        messages: List[Any],
     ) -> Record:
         """Compute summary statistics for a list of messages.
 
@@ -206,7 +210,11 @@ class Aggregator:
 
                 try:
                     operation = aggregation_field.operation.value
-                    aggregated_value = eval(operation)(values)
+                    # Make sure there are enough values to compute statistics
+                    if len(values) >= min_sample_size:
+                        aggregated_value = eval(operation)(values)
+                    else:
+                        aggregated_value = values[0]
                 except Exception:
                     msg = f"Error computing {operation} of {values}."
                     raise StatisticsError(msg)

--- a/src/kafkaaggregator/config.py
+++ b/src/kafkaaggregator/config.py
@@ -66,6 +66,18 @@ class Configuration:
     from the stream are persisted by Faust.
     """
 
+    min_sample_size: int = int(os.getenv("MIN_SAMPLE_SIZE", "2"))
+    """Minimum sample size to compute statistics.
+
+    Given the size of the tumbling window and the frequency of incoming
+    messages, this parameter sets the minimum sample size to compute
+    statistics. The Faust tumbling window will always contain at least one
+    message. If the number messages in the tumbling window is smaller than
+    min_sample_size the values of the first message are used instead.
+
+    The default value min_sample_size=2 make sure we can compute stdev.
+    """
+
     topic_partitions: int = int(os.getenv("TOPIC_PARTITIONS", "4"))
     """Default number of partitions for new topics.
 

--- a/src/kafkaaggregator/templates/agent.j2
+++ b/src/kafkaaggregator/templates/agent.j2
@@ -78,8 +78,9 @@ def process_window(key: Tuple, value: List[Any]) -> None:
     aggregation_topic.send_soon(value=aggregated_message)
 
     logger.info(
-        f"{aggregated_message.count:5d} messages aggregated on window "
-        f"({start}, {end + 0.1})."
+        f"{aggregated_message.count:5d} messages aggregated on "
+        f"{{ source_topic_name }}-tumbling-window ({start:.2f}, "
+        f"{(end + 0.1):.2f})."
     )
 
 

--- a/src/kafkaaggregator/templates/agent.j2
+++ b/src/kafkaaggregator/templates/agent.j2
@@ -72,7 +72,10 @@ def process_window(key: Tuple, value: List[Any]) -> None:
     time = (start + end + 0.1) / 2
 
     aggregated_message = aggregator.compute(
-        time=time, window_size=config.window_size, messages=value
+        time=time,
+        window_size=config.window_size,
+        min_sample_size=config.min_sample_size,
+        messages=value
     )
 
     aggregation_topic.send_soon(value=aggregated_message)

--- a/src/kafkaaggregator/topics.py
+++ b/src/kafkaaggregator/topics.py
@@ -168,7 +168,7 @@ class SourceTopic(Topic):
 
         n = len(names)
         s = ", ".join(sorted(names))
-        logger.info(f"Found {n} topic(s): {s}")
+        logger.info(f"Found {n} source topic(s): {s}")
 
         return names
 

--- a/tests/kafkaaggregator/test_compute.py
+++ b/tests/kafkaaggregator/test_compute.py
@@ -10,7 +10,7 @@ from kafkaaggregator.models import make_record
 
 
 @pytest.fixture
-def incoming_messages():
+def incoming_messages() -> List[Any]:
     """Mock incoming messages."""
     messages = [
         {"time": 0, "value": 1.0},
@@ -21,7 +21,7 @@ def incoming_messages():
 
 
 @pytest.fixture
-def aggregation_fields():
+def aggregation_fields() -> List[Field]:
     """Mock aggregation fields."""
     fields = [
         Field("time", int),
@@ -37,7 +37,7 @@ def aggregation_fields():
 
 
 @pytest.fixture
-def expected_result():
+def expected_result() -> Mapping[str, Any]:
     """Return test expected result."""
     result = {
         "count": 3,

--- a/tests/kafkaaggregator/test_compute.py
+++ b/tests/kafkaaggregator/test_compute.py
@@ -85,7 +85,10 @@ def test_compute(
         doc="Faust record for topic test-source-topic.",
     )
     aggregated_message = Agg.compute(
-        time=1.0, window_size=1.0, messages=incoming_messages
+        time=1.0,
+        window_size=1.0,
+        min_sample_size=1,
+        messages=incoming_messages
     )
     assert aggregated_message.is_valid()
     assert aggregated_message.asdict() == expected_result

--- a/tests/kafkaaggregator/test_compute.py
+++ b/tests/kafkaaggregator/test_compute.py
@@ -52,10 +52,31 @@ def expected_result() -> Mapping[str, Any]:
     return result
 
 
+@pytest.fixture
+def first_message_value(incoming_messages: List[Any]) -> Mapping[str, Any]:
+    """Return the value of the first message instead of computing statistics.
+
+    That's the expected result if the number of messages in the aggregation
+    window is smaller than the min_sample_size.
+    """
+    result = {
+        "count": 3,
+        "min_value": incoming_messages[0]["value"],
+        "time": 1.0,  # timestamp of the aggregated message
+        "window_size": 1.0,
+        "max_value": incoming_messages[0]["value"],
+        "mean_value": incoming_messages[0]["value"],
+        "median_value": incoming_messages[0]["value"],
+        "stdev_value": incoming_messages[0]["value"],
+    }
+    return result
+
+
 def test_compute(
     incoming_messages: List[Any],
     aggregation_fields: List[Field],
     expected_result: Mapping[str, Any],
+    first_message_value: Mapping[str, Any],
 ) -> None:
     """Test the Aggregator compute method.
 
@@ -88,7 +109,17 @@ def test_compute(
         time=1.0,
         window_size=1.0,
         min_sample_size=1,
-        messages=incoming_messages
+        messages=incoming_messages,
     )
     assert aggregated_message.is_valid()
     assert aggregated_message.asdict() == expected_result
+
+    # Test the case where the min_sample_size is larger than the number
+    # of messages in the aggregation window
+    aggregated_message = Agg.compute(
+        time=1.0,
+        window_size=1.0,
+        min_sample_size=5,
+        messages=incoming_messages,
+    )
+    assert aggregated_message.asdict() == first_message_value


### PR DESCRIPTION
This PR adds the minimum sample size configuration (`config.min_sample_size`) to compute statistics.

Given the size of the window and the frequency of incoming messages, the `config.min_sample_size` configuration parameter sets the minimum sample size to compute statistics. The Faust tumbling window will always contain at least one message. If the number of messages in the tumbling window is smaller than `config.min_sample_size` the values of the first message are used instead.