### PR TITLE
[DM-25676] Evaluate Kafdrop UI

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,6 +34,23 @@ services:
       CONFLUENT_METRICS_ENABLE: 'true'
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
+  kafdrop:
+    image: obsidiandynamics/kafdrop
+    hostname: kafdrop
+    container_name: kafdrop
+    depends_on:
+      - zookeeper
+      - broker
+      - schema-registry
+      - internal-schema-registry
+    ports:
+      - "9000:9000"
+    environment:
+      KAFKA_BROKERCONNECT: "broker:29092"
+      JVM_OPTS: "-Xms32M -Xmx64M"
+      SERVER_SERVLET_CONTEXTPATH: "/"
+      CMD_ARGS: "--message.format=AVRO --schemaregistry.connect=http://internal-schema-registry:28081"
+
   control-center:
     image: confluentinc/cp-enterprise-control-center:5.3.2
     hostname: control-center


### PR DESCRIPTION
This PR adds Kafdrop to the docker-compose setup for evaluation. Kafdrop is an open-source alternative to replace some of the Confluent Control Center features.

It is configured to use the `internal-schema-registry` to deserialize the aggregated messages.