### PR TITLE
[DM-25722] Allow the kafka-aggregator example to produce an indefinite number of messages

### DIFF
--- a/src/kafkaaggregator/cli.py
+++ b/src/kafkaaggregator/cli.py
@@ -8,6 +8,7 @@ from faust.cli import AppCommand, option
 
 from kafkaaggregator.app import app
 from kafkaaggregator.example import AggregationExample
+from kafkaaggregator.app import app, config
 from kafkaaggregator.generator import AgentGenerator
 
 logger = logging.getLogger("kafkaaggregator")
@@ -22,14 +23,14 @@ def main() -> None:
     option(
         "--frequency",
         type=float,
-        default=10,
+        default=config.frequency,
         help="The frequency in Hz in wich messages are produced.",
         show_default=True,
     ),
     option(
         "--max-messages",
         type=int,
-        default=600,
+        default=config.max_messages,
         help="The maximum number of messages to produce.",
         show_default=True,
     ),

--- a/src/kafkaaggregator/cli.py
+++ b/src/kafkaaggregator/cli.py
@@ -6,9 +6,11 @@ import logging
 
 from faust.cli import AppCommand, option
 
-from kafkaaggregator.app import app
-from kafkaaggregator.example import AggregationExample
 from kafkaaggregator.app import app, config
+from kafkaaggregator.example import (
+    AggregationExample,
+    UnexpectedNumberOfTopicsError,
+)
 from kafkaaggregator.generator import AgentGenerator
 
 logger = logging.getLogger("kafkaaggregator")
@@ -40,9 +42,13 @@ async def produce(
 ) -> None:
     """Produce messages for the aggregation example."""
     example = AggregationExample()
-    await example.produce(
-        app=app, frequency=frequency, max_messages=max_messages
-    )
+
+    try:
+        await example.produce(
+            app=app, frequency=frequency, max_messages=max_messages
+        )
+    except UnexpectedNumberOfTopicsError as e:
+        logger.error(e)
 
 
 @app.command()

--- a/src/kafkaaggregator/config.py
+++ b/src/kafkaaggregator/config.py
@@ -96,6 +96,16 @@ class Configuration:
     nfields: int = int(os.getenv("NFIELDS", "10"))
     """Number of fields for source topics used in the aggregation example."""
 
+    frequency: float = float(os.getenv("FREQUENCY", "10"))
+    """The frequency in Hz in which messages are produced for the
+    example topics.
+    """
+
+    max_messages: int = int(os.getenv("MAX_MESSAGES", "10"))
+    """The maximum number of messages to produce. Set max_messages to a number
+    smaller than 1 to produce an indefinite number of messages.
+    """
+
     topic_regex: str = os.getenv("TOPIC_REGEX", "^example-[0-9][0-9][0-9]?$")
     """Regex to select source topics to aggregate."""
 

--- a/src/kafkaaggregator/example.py
+++ b/src/kafkaaggregator/example.py
@@ -19,7 +19,7 @@ AvroSchemaT = str
 logger = logging.getLogger("kafkaaggregator")
 
 
-class AggregationExampleError(RuntimeError):
+class UnexpectedNumberOfTopicsError(RuntimeError):
     """Raised when the number of source topics is unnexpected.
 
     The number of source topics in Kafka must match the number of topics
@@ -116,7 +116,7 @@ class AggregationExample:
                 "verify if the topic_regex configuration matches the "
                 "source topic names."
             )
-            raise AggregationExampleError(msg)
+            raise UnexpectedNumberOfTopicsError(msg)
         logger.info(
             f"Producing {max_messages} message(s) at {frequency} Hz for each "
             f"source topic."

--- a/src/kafkaaggregator/example.py
+++ b/src/kafkaaggregator/example.py
@@ -118,10 +118,11 @@ class AggregationExample:
             )
             raise UnexpectedNumberOfTopicsError(msg)
         logger.info(
-            f"Producing {max_messages} message(s) at {frequency} Hz for each "
-            f"source topic."
+            f"Producing message(s) at {frequency} Hz for each source topic."
         )
-        for i in range(max_messages):
+        count = 0
+        send_count = 0
+        while True:
             message = {"time": time()}
             for n in range(self._nfields):
                 value = random.random()
@@ -130,5 +131,12 @@ class AggregationExample:
             for source_topic_name in source_topic_names:
                 source_topic = app.topic(source_topic_name)
                 await source_topic.send(value=message)
+                send_count += 1
 
             await asyncio.sleep(1 / frequency)
+            # Allow for an indefinite loop if max_messages is a number
+            # smaller than 1
+            count += 1
+            if count == max_messages:
+                logger.info(f"{send_count} messages sent.")
+                break


### PR DESCRIPTION
This PR adds the produce parameters to the configuration, improve error handling and allow an indefinite number of messages to be produced by the Kafka-aggregator example, which is useful for performance tests.