### PR TITLE
[DM-25844] Add configuration for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,17 @@
+{
+  "enabledManagers": [
+    "docker-compose",
+    "kustomize"
+  ],
+  "extends": [
+    "config:base"
+  ],
+  "packageRules": [
+    {
+      "groupName": "test dependencies",
+      "paths": [
+        "docker-compose.yaml"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Enable GitHub Actions and Docker dependency monitoring.  This will
also switch to using the GitHub integrated Dependabot instead of
Dependabot Preview, allowing us to eventually remove the latter
application.