### PR TITLE
[DM-25811] Add quartiles to the list of operations supported by the kafka-aggregator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2.1.1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install tox
         run: pip install tox
@@ -76,7 +76,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2.1.1
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Install tox and LTD Conveyor
         run: pip install tox ltd-conveyor
       - name: Install graphviz

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ update-deps:
 	pip install --upgrade pip-tools pip setuptools
 	pip-compile --upgrade --build-isolation --generate-hashes --output-file requirements/main.txt requirements/main.in
 	pip-compile --upgrade --build-isolation --generate-hashes --output-file requirements/dev.txt requirements/dev.in
+	pip-sync requirements/main.txt requirements/dev.txt
 
 .PHONY: init
 init:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -44,6 +44,12 @@ Selecting topics to aggregate
 
 kafka-aggregator selects source topics from Kafka using a regular expression `topic_regex` and exclude source topics listed in the `excluded_topics` list.
 
+Summary Statistics
+------------------
+The `operations` configuration setting specifies the summary statistics to be computed for each
+numerical field in the source topic.
+
+
 Aggregation window settings
 ---------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,14 +4,16 @@ Kafka-aggregator
 
 A Kafka aggregator based on the `Faust <https://faust.readthedocs.io/en/latest/index.html>`_ Python Stream Processing library.
 
-This site provides documentation for the kafka-aggregator installation, configuration, user and development guides, and API reference. Before installing kafka-aggregator, you might want to use the docker-compose set up as a way to run it locally, in this case jump straight to the `Configuration`_ and `User guide`_ sessions.
+This site provides documentation for the kafka-aggregator installation, configuration, user and development guides, and API reference.
+
+Before installing kafka-aggregator, you might want to use the docker-compose set up as a way to run it locally, in this case jump straight to the `Configuration`_ and `User guide`_ sessions.
 
 Overview
 ========
 
-kafka-aggregator uses `Faust's windowing feature <https://faust.readthedocs.io/en/latest/userguide/tables.html#windowing>`_  to aggregate a stream of messages from Kafka.
+kafka-aggregator uses `Faust's windowing feature <https://faust.readthedocs.io/en/latest/userguide/tables.html#windowing>`_  to aggregate Kafka streams.
 
-kafka-aggregator implements a Faust agent (stream processor) that adds messages from a source topic into a Faust table. The table is configured as a tumbling window with a size, representing the window duration (time interval) and an expiration time, which specifies the duration for which the data allocated to each window will be stored. Every time a window expires, a callback function is called to aggregate the messages allocated to that window. The size of the window controls the frequency of the aggregated stream.
+kafka-aggregator implements a Faust agent (stream processor) that adds messages from a source topic into a Faust table. The table is configured as a tumbling window with a size and an expiration time. Every time a window expires, a callback function is called to aggregate the messages allocated to that window. The size of the window controls the frequency of the aggregated stream.
 
 kafka-aggregator uses `faust-avro <https://github.com/masterysystems/faust-avro>`_ to add Avro serialization and Schema Registry support to Faust.
 
@@ -23,7 +25,7 @@ kafka-aggregator uses `faust-avro <https://github.com/masterysystems/faust-avro>
 
 Summary statistics
 ------------------
-kafka-aggregator uses the `Python statistics`_ module to compute summary statistics for each field in the messages allocated to an aggregation window.
+kafka-aggregator uses the `Python statistics`_ module to compute summary statistics for each numerical field in the source topic.
 
 .. table:: *Summary statistics computed by kafka-aggregator*.
 
@@ -37,6 +39,10 @@ kafka-aggregator uses the `Python statistics`_ module to compute summary statist
   | max()    | Maximum value of data.               |
   +----------+--------------------------------------+
   | stdev()  | Sample standard deviation of data.   |
+  +----------+--------------------------------------+
+  | q1()     | First quartile of the data.          |
+  +----------+--------------------------------------+
+  | q3()     | Third quartile of the data.          |
   +----------+--------------------------------------+
 
 .. _Python statistics: https://docs.python.org/3/library/statistics.html

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -5,17 +5,17 @@
 # After editing, update requirements/dev.txt by running:
 #     make update-deps
 
-pre-commit
-coverage[toml]
-flake8
-flake8-docstrings
-mypy
-pytest
-pytest-asyncio
-pytest-vcr
-documenteer>=0.5,<0.6
-lsst-sphinx-bootstrap-theme<0.3
-sphinx-automodapi
-sphinx-prompt
-sphinx-click
-graphviz
+pre-commit==2.6.0
+coverage[toml]==5.2.1
+flake8==3.8.3
+flake8-docstrings==1.5.0
+mypy==0.782
+pytest==6.0.1
+pytest-asyncio==0.14.0
+pytest-vcr==1.0.2
+documenteer==0.5.8
+lsst-sphinx-bootstrap-theme==0.2.2
+sphinx-automodapi==0.12
+sphinx-prompt==1.2.0
+sphinx-click==2.5.0
+graphviz==0.14.1

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -5,8 +5,8 @@
 # After editing, update requirements/main.txt by running:
 #     make update-deps
 
-faust[fast]
-faust-avro
-importlib_metadata
-jinja2
-aiofiles
+faust[fast]==1.10.4
+faust-avro==0.4.0
+importlib_metadata==1.7.0
+jinja2==2.11.2
+aiofiles==0.5.0

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -198,7 +198,7 @@ idna==2.10 \
     --hash=sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6 \
     --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0 \
     # via yarl
-importlib-metadata==1.7.0 \
+importlib_metadata==1.7.0 \
     --hash=sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83 \
     --hash=sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070 \
     # via -r requirements/main.in

--- a/src/kafkaaggregator/fields.py
+++ b/src/kafkaaggregator/fields.py
@@ -1,25 +1,14 @@
-"""Represents an aggregation field and possible operations on fields.
+"""Aggregation field class.
 
-The Field has a numerical type by construction
-(only numeric fields are aggregated).
-It also holds the name of the source field aggregated and the operation
-performed.
+The Field has a numerical type by construction. It also holds the name of
+the source field being aggregated and the operation performed.
 """
 
-__all__ = ["Field", "Operation"]
+__all__ = ["Field"]
 
-from enum import Enum
 from typing import Mapping, Optional, Tuple, Type, Union
 
-
-class Operation(Enum):
-    """Possible operations on fields."""
-
-    MIN = "min"
-    MEAN = "mean"
-    MEDIAN = "median"
-    STDEV = "stdev"
-    MAX = "max"
+from kafkaaggregator.operations import Operation
 
 
 class Field:
@@ -33,7 +22,7 @@ class Field:
         Field data type.
     source_field_name : `str`, optional
         Source field name.
-    operation : `Operation`, optional
+    operation : `str`, optional
     """
 
     def __init__(
@@ -41,16 +30,17 @@ class Field:
         name: str,
         type: Union[Type[int], Type[float]],
         source_field_name: Optional[str] = None,
-        operation: Optional[Operation] = None,
+        operation: Optional[str] = None,
     ) -> None:
         self.name = name
         self.type = type
         self.source_field_name = source_field_name
         self.operation = operation
         if operation:
-            if not isinstance(operation, Operation):
-                raise TypeError(
-                    "Operation must be an instance of the Operation Enum."
+            if operation not in Operation.values():
+                raise RuntimeError(
+                    f"Invalid operation '{operation}'. "
+                    f"Allowed values are: {', '.join(Operation.values())}."
                 )
 
     def __repr__(self) -> str:

--- a/src/kafkaaggregator/operations.py
+++ b/src/kafkaaggregator/operations.py
@@ -1,0 +1,58 @@
+"""Possible statistical operations on fields."""
+
+__all__ = ["Operation", "q1", "q3"]
+
+from enum import Enum
+from statistics import mean, median, quantiles, stdev  # noqa: F401
+from typing import List
+
+
+class Operation(Enum):
+    """Possible statistical operations on fields."""
+
+    MIN = "min"
+    Q1 = "q1"
+    MEAN = "mean"
+    MEDIAN = "median"
+    Q3 = "q3"
+    STDEV = "stdev"
+    MAX = "max"
+
+    @staticmethod
+    def values() -> List[str]:
+        """Return list of possible operations."""
+        return list(map(lambda op: op.value, Operation))
+
+
+def q1(data: List[float]) -> float:
+    """Compute the data first quartile.
+
+    Parameters
+    ----------
+    data: `list`
+        List of values to compute the statistics from.
+
+    Returns
+    -------
+    value: `float`
+        The data first quartile.
+    """
+    quartiles = quantiles(data, n=4)
+    return quartiles[0]
+
+
+def q3(data: List[float]) -> float:
+    """Compute the daa third quartile.
+
+    Parameters
+    ----------
+    data: `list`
+        List of values to compute the statistics from.
+
+    Returns
+    -------
+    value: `float`
+        The data first quartile.
+    """
+    quartiles = quantiles(data, n=4)
+    return quartiles[2]

--- a/src/kafkaaggregator/templates/agent.j2
+++ b/src/kafkaaggregator/templates/agent.j2
@@ -34,6 +34,7 @@ aggregator = Aggregator(
     source_topic_name="{{ source_topic_name }}",
     aggregation_topic_name="{{ aggregation_topic_name }}",
     excluded_field_names=config.excluded_field_names,
+    operations=config.operations,
 )
 
 # The Faust Record for the aggregation topic is created at runtime

--- a/tests/kafkaaggregator/test_aggregator.py
+++ b/tests/kafkaaggregator/test_aggregator.py
@@ -26,10 +26,18 @@ def excluded_field_names():
     return ["time", "excluded"]
 
 
-def test_aggregation_fields(source_topic_fields, excluded_field_names):
+@pytest.fixture
+def operations():
+    """Mock list of opertions."""
+    return ["min", "mean", "median", "stdev", "max"]
+
+
+def test_aggregation_fields(
+    source_topic_fields, excluded_field_names, operations
+):
     """Test aggregation fields creation."""
     aggregation_fields = Aggregator._create_aggregation_fields(
-        source_topic_fields, excluded_field_names
+        source_topic_fields, excluded_field_names, operations
     )
     # `time`, `count` and `window_size` are added by the aggregator
     assert Field("time", float) in aggregation_fields

--- a/tests/kafkaaggregator/test_compute.py
+++ b/tests/kafkaaggregator/test_compute.py
@@ -5,7 +5,7 @@ from typing import Any, List, Mapping
 import pytest
 
 from kafkaaggregator.aggregator import Aggregator
-from kafkaaggregator.fields import Field, Operation
+from kafkaaggregator.fields import Field
 from kafkaaggregator.models import make_record
 
 
@@ -27,11 +27,11 @@ def aggregation_fields() -> List[Field]:
         Field("time", int),
         Field("count", int),
         Field("window_size", float),
-        Field("min_value", float, "value", Operation.MIN),
-        Field("mean_value", float, "value", Operation.MEAN),
-        Field("median_value", float, "value", Operation.MEDIAN),
-        Field("stdev_value", float, "value", Operation.STDEV,),
-        Field("max_value", float, "value", Operation.MAX),
+        Field("min_value", float, "value", "min"),
+        Field("mean_value", float, "value", "mean"),
+        Field("median_value", float, "value", "median"),
+        Field("stdev_value", float, "value", "stdev"),
+        Field("max_value", float, "value", "max"),
     ]
     return fields
 
@@ -95,6 +95,7 @@ def test_compute(
         # If these fields are present in the incoming message they are excluded
         # as they are used by the aggregator
         excluded_field_names="time, count, window_size",
+        operations=["min", "mean", "median", "stdev", "max"],
     )
 
     # Mock the creation of the aggregation fields

--- a/tests/kafkaaggregator/test_fields.py
+++ b/tests/kafkaaggregator/test_fields.py
@@ -1,6 +1,6 @@
 """Tests for the fields module."""
 
-from kafkaaggregator.fields import Field, Operation
+from kafkaaggregator.fields import Field
 
 
 def test_hash() -> None:
@@ -10,9 +10,6 @@ def test_hash() -> None:
     """
     assert hash(
         Field(
-            "field",
-            int,
-            source_field_name="source_field",
-            operation=Operation.MEAN,
+            "field", int, source_field_name="source_field", operation="mean",
         )
     )

--- a/tests/kafkaaggregator/test_operations.py
+++ b/tests/kafkaaggregator/test_operations.py
@@ -1,0 +1,12 @@
+"""Tests for the fields module."""
+import pytest
+
+from kafkaaggregator.fields import Field
+
+
+def test_invalid_operation() -> None:
+    """Test for invalid operation."""
+    with pytest.raises(RuntimeError):
+        Field(
+            "field", int, source_field_name="source_field", operation="maximum"
+        )


### PR DESCRIPTION
- Move `Operation` class to its own module
- Add functions to compute first and third quartiles
- Update `Aggregator` class, agent template code, tests and documentation.