### PR TITLE
[DM-31621] Update how workflows run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,17 @@
 name: CI
 
-"on": [push]
+"on":
+  push:
+    branches-ignore:
+      # These should always correspond to pull requests, so ignore them for
+      # the push trigger and let them be triggered by the pull_request
+      # trigger, avoiding running the workflow twice.  This is a minor
+      # optimization so there's no need to ensure this is comprehensive.
+      - "dependabot/**"
+      - "renovate/**"
+      - "tickets/**"
+      - "u/**"
+  pull_request: {}
 
 jobs:
   test:
@@ -90,26 +101,6 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: Install tox and LTD Conveyor
-        run: pip install tox ltd-conveyor
-      - name: Install graphviz
-        run: sudo apt-get install graphviz
-      - name: Run tox
-        run: tox -e docs
-      - name: Upload to LSST the Docs
-        env:
-          LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
-          LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
-        run: ltd upload --product kafka-aggregator --gh --dir docs/_build/html
 
   pypi:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,41 @@
+name: Docs
+
+"on":
+  push:
+    branches:
+      - main
+      - master
+      - "tickets/**"
+      - "u/**"
+    paths:
+      - "CHANGELOG.rst"
+      - "docs/**"
+      - "src/**.py"
+    tags:
+      - "*"
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install tox and LTD Conveyor
+        run: pip install tox ltd-conveyor
+
+      - name: Install graphviz
+        run: sudo apt-get install graphviz
+
+      - name: Run tox
+        run: tox -e docs
+
+      - name: Upload to LSST the Docs
+        env:
+          LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
+          LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
+        run: ltd upload --product kafka-aggregator --gh --dir docs/_build/html


### PR DESCRIPTION
Our previous approach of running CI workflows on push but not pull
request is fairly hostile to external contributors.  Enable
workflows for pull requests in the relevant templates.  We also
want to re-run CI workflows on tags and merges to master to confirm
nothing broke, so also enable push CI but exclude the branches we
use to create local pull requests to avoid running the CI workflow
twice and wasting some resources.

It's not a big deal if we run workflows twice occasionally, so this
list of exclusions doesn't need to be comprehensive.

Move docs to its own workflow and trigger it only on pushes to
ticket branches, user branches, main, or master, plus any tags.
This pattern is copied from Gafaelfawr and avoids trying to run the
docs workflow on dependabot and renovate branches, which do not have
access to the relevant secrets (and don't produce useful docs).  Also
limit documentation builds to commits that may change the
documentation.